### PR TITLE
Data file upload support

### DIFF
--- a/backend/core_plugins/data_file_server.py
+++ b/backend/core_plugins/data_file_server.py
@@ -51,8 +51,19 @@ class DataFileAPI(HTTPEndpoint):
         pass
 
 
+class DataFileCreateEndpoint(HTTPEndpoint):
+    async def post(self, request):
+        form = await request.form()
+        filename = form["upload_file"].filename
+        contents = await form["upload_file"].read()
+        return JSONResponse({"success": True, "filename": filename})
+
+
 class DataFilePlugin(SparrowCorePlugin):
     name = "data-file"
 
     def on_api_initialized_v2(self, api):
+        api.mount(
+            "/data_file_new", DataFileCreateEndpoint, name="data_file_api_import", help="Import a data file [WIP]"
+        )
         api.mount("/data_file/{uuid}", DataFileAPI, name="data_file_api", help="Download a data file by URL")

--- a/backend/core_plugins/data_file_server.py
+++ b/backend/core_plugins/data_file_server.py
@@ -47,6 +47,9 @@ class DataFileAPI(HTTPEndpoint):
             }
         )
 
+    async def post(self, request):
+        pass
+
 
 class DataFilePlugin(SparrowCorePlugin):
     name = "data-file"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,6 +70,9 @@ webargs-starlette==2.0.0
 apispec==3.3.1
 starlette-apispec==1.0.3
 
+# File upload parsing
+python-multipart==0.0.5
+
 # S3/AWS file access
 boto3==1.12.25
 

--- a/backend/sparrow/plugins/manager.py
+++ b/backend/sparrow/plugins/manager.py
@@ -71,9 +71,7 @@ class SparrowPluginManager(object):
         try:
             self.__init_store.append(plugin)
         except AttributeError:
-            raise SparrowPluginError(
-                "Cannot add plugins after Sparrow is finished loading."
-            )
+            raise SparrowPluginError("Cannot add plugins after Sparrow is finished loading.")
         except Exception as err:
             handle_load_error(plugin, err)
 
@@ -97,9 +95,7 @@ class SparrowPluginManager(object):
         store = store or self.__store
         for p in store:
             if getattr(p, "name") is None:
-                raise SparrowPluginError(
-                    f"Sparrow plugin '{p}' must have a name attribute."
-                )
+                raise SparrowPluginError(f"Sparrow plugin '{p}' must have a name attribute.")
         struct = {p.name: set(p.dependencies) for p in store}
         map = {p.name: p for p in store}
         res = toposort_flatten(struct)
@@ -107,9 +103,7 @@ class SparrowPluginManager(object):
 
     def __load_plugin(self, plugin_class, app):
         if not issubclass(plugin_class, SparrowPlugin):
-            raise SparrowPluginError(
-                "Sparrow plugins must be a subclass of SparrowPlugin"
-            )
+            raise SparrowPluginError("Sparrow plugins must be a subclass of SparrowPlugin")
         return plugin_class(app)
 
     def finalize(self, app):

--- a/backend/sparrow_tests/fixtures/simple-sims-session.json
+++ b/backend/sparrow_tests/fixtures/simple-sims-session.json
@@ -6,7 +6,7 @@
     {
       "analysis_name": "20140513@171.asc",
       "analysis_type": "d18O10",
-      "datums": [
+      "datum": [
         {
           "value": 251,
           "type": { "parameter": "INDEX", "unit": "INDEXexcel" }

--- a/backend/sparrow_tests/test_data_file_api.py
+++ b/backend/sparrow_tests/test_data_file_api.py
@@ -1,0 +1,23 @@
+"""
+Tests for importing data files via the API
+"""
+from sparrow.util import relative_path
+from .helpers import json_fixture
+
+
+class TestDataFileAPI:
+    def test_file_import(self, client):
+        """Uploads a file but doesn't do anything with it yet"""
+        filename = "simple-sims-session.json"
+        pth = relative_path(__file__, "fixtures", filename)
+
+        files = {"upload_file": open(pth, "rb")}
+        res = client.post("/api/v2/data_file_new", files=files, allow_redirects=True)
+        data = res.json()
+        assert data["success"] == True
+        assert data["filename"] == filename
+
+    def test_api_import(self, client):
+        data = json_fixture("simple-sims-session.json")
+        res = client.put("/api/v1/import-data/session", json={"filename": None, "data": data})
+        assert res.status_code == 201


### PR DESCRIPTION
This pull request tracks an in-progress change to enable data file uploading from the importer API, in response to #74 .

Right now we can get the contents of specific data files and upload data file content to the Sparrow server (right now, that content is not saved or tracked in any way!) A few things to do:

- [ ] Store uploaded data files in `SPARROW_DATA_DIR` (or complain if that is undefined/nonexistent)
- [ ] If the Cloud Data plugin is active, store the file in the relevant S3 bucket instead
- [ ] Return a UUID from the POST route
- [ ] Decide whether associated data should be posted at the same time or in a separate request
- [ ] Figure out how to encode data file -> inserted model links properly
- [ ] Some API for getting a data file given its file path
- [ ] Add authentication