### PR TITLE
Query speed!!

### DIFF
--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -186,7 +186,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
     async def api_docs(self, request, schema):
         return JSONResponse(
             {
-                "liscense": "CC-BY 4.0",
+                "license": "CC-BY 4.0",
                 "description": str(self.description),
                 "parameters": dict(self.build_param_help()),
                 "allowed_nests": list(set(schema._available_nests())),

--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -224,8 +224,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
         for _filter in self._filters:
             q = _filter(q, args)
 
-        joins = [joinedload(*rel) for rel in schema.nested_relationships()]
-        q = q.options(*joins)
+        q = q.options(*list(schema.query_options()))
 
         if args["all"]:
             res = q.all()

--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -224,7 +224,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
         for _filter in self._filters:
             q = _filter(q, args)
 
-        joins = [joinedload(rel) for rel in schema.nested_relationships()]
+        joins = [joinedload(*rel) for rel in schema.nested_relationships()]
         q = q.options(*joins)
 
         if args["all"]:

--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -4,6 +4,7 @@ from webargs.fields import DelimitedList, Str, Int, Boolean
 from sqlakeyset import get_page
 from marshmallow_sqlalchemy.fields import get_primary_keys
 from sqlalchemy import desc
+from sqlalchemy.orm import joinedload
 from starlette.responses import JSONResponse
 from yaml import safe_load
 
@@ -219,8 +220,12 @@ class ModelAPIEndpoint(HTTPEndpoint):
             return await self.api_docs(request, schema)
 
         q = self.query(schema)  # constructs query to send to database
+
         for _filter in self._filters:
             q = _filter(q, args)
+
+        joins = [joinedload(rel) for rel in schema.nested_relationships()]
+        q = q.options(*joins)
 
         if args["all"]:
             res = q.all()

--- a/backend/sparrow/database/__init__.py
+++ b/backend/sparrow/database/__init__.py
@@ -38,7 +38,7 @@ class Database:
         the SPARROW_BACKEND_CONFIG file, if available.
         """
         log.info(f"Setting up database connection '{db_conn}'")
-        self.engine = create_engine(db_conn, executemany_mode="batch")
+        self.engine = create_engine(db_conn, executemany_mode="batch", echo=False)
         metadata.create_all(bind=self.engine)
         self.meta = metadata
         self.app = app

--- a/backend/sparrow/interface/fields.py
+++ b/backend/sparrow/interface/fields.py
@@ -84,6 +84,10 @@ class SmartNested(Nested, Related):
         self._instances = set()
         self.allow_none = True
 
+        # Pass through allowed_nests configuration to child schema
+        self._copy_config("allowed_nests")
+        self._copy_config("_show_audit_id")
+
     def _deserialize(self, value, attr=None, data=None, **kwargs):
         if isinstance(value, self.schema.opts.model):
             return value
@@ -115,14 +119,18 @@ class SmartNested(Nested, Related):
         self._instances.add(value)
         return self._serialize_related_key(value)
 
+    def _should_nest(self):
+        other_name = self.related_model.__table__.name
+        _allowed = self.root.allowed_nests
+        return other_name in _allowed or _allowed == "all"
+
     def _serialize(self, value, attr, obj):
         # Pass through allowed_nests configuration to child schema
+        # Unclear why we have to do this again, but a test fails
         self._copy_config("allowed_nests")
         self._copy_config("_show_audit_id")
 
-        other_name = self.related_model.__table__.name
-        _allowed = self.root.allowed_nests
-        if other_name in _allowed or _allowed == "all":
+        if self._should_nest():
             # Serialize as nested
             return super(Nested, self)._serialize(value, attr, obj)
         # If we don't want to nest

--- a/backend/sparrow/interface/schema.py
+++ b/backend/sparrow/interface/schema.py
@@ -90,13 +90,15 @@ class ModelSchema(SQLAlchemyAutoSchema):
         for key, field in self.fields.items():
             if not isinstance(field, SmartNested):
                 continue
+            # Yield this relationship
+            this_relationship = getattr(self.opts.model, key)
+            yield [this_relationship]
+            field.schema.allowed_nests = _nests
             if not field._should_nest():
                 continue
-            # Yield this relationship
-            yield getattr(self.opts.model, key)
-            field.schema.allowed_nests = _nests
             # Get relationships from nested models
-            yield from field.schema._nested_relationships(nests=_nests)
+            for nested in field.schema._nested_relationships(nests=_nests):
+                yield [this_relationship, *nested]
 
     def nested_relationships(self):
         return list(self._nested_relationships())

--- a/backend/sparrow/interface/schema.py
+++ b/backend/sparrow/interface/schema.py
@@ -93,7 +93,7 @@ class ModelSchema(SQLAlchemyAutoSchema):
             if not field._should_nest():
                 continue
             # Yield this relationship
-            yield getattr(self.opts.model, key).property
+            yield getattr(self.opts.model, key)
             field.schema.allowed_nests = _nests
             # Get relationships from nested models
             yield from field.schema._nested_relationships(nests=_nests)

--- a/backend/sparrow/logs/config.py
+++ b/backend/sparrow/logs/config.py
@@ -5,7 +5,9 @@ workers = 1
 # We may want to customize this further eventually
 logconfig_dict = {
     "version": 1,
-    "formatters": {"colored": {"class": "sparrow.logs.SparrowLogFormatter"},},
+    "formatters": {
+        "colored": {"class": "sparrow.logs.SparrowLogFormatter"},
+    },
     "handlers": {
         "error_console": {
             "level": "INFO",
@@ -25,7 +27,11 @@ logconfig_dict = {
             "propagate": False,
         },
         "hypercorn.access": {"level": "ERROR", "propagate": False},
-        "sparrow": {"handlers": ["default"], "level": "DEBUG", "propagate": False,},
+        "sparrow": {
+            "handlers": ["default"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
         "sqlalchemy.engine": {
             "handlers": ["default"],
             "level": "INFO",

--- a/backend/sparrow_tests/conftest.py
+++ b/backend/sparrow_tests/conftest.py
@@ -59,6 +59,18 @@ def app(pytestconfig):
         yield _app
 
 
+@fixture(scope="function")
+def statements(db):
+    stmts = []
+
+    def catch_queries(conn, cursor, statement, parameters, context, executemany):
+        stmts.append(statement)
+
+    event.listen(db.engine, "before_cursor_execute", catch_queries)
+    yield stmts
+    event.remove(db.engine, "before_cursor_execute", catch_queries)
+
+
 @fixture(scope="class")
 def db(app, pytestconfig):
     # https://docs.sqlalchemy.org/en/13/orm/session_transaction.html

--- a/backend/sparrow_tests/conftest.py
+++ b/backend/sparrow_tests/conftest.py
@@ -43,6 +43,7 @@ def pytest_addoption(parser):
         help="Tear down database after tests run",
     )
 
+
 def pytest_configure(config):
     if not config.option.slow:
         setattr(config.option, "markexpr", "not slow")
@@ -91,6 +92,7 @@ def db(app, pytestconfig):
         connection.close()
     else:
         yield app.database
+
 
 @fixture(scope="class")
 def client(app, db):

--- a/backend/sparrow_tests/test_api.py
+++ b/backend/sparrow_tests/test_api.py
@@ -128,3 +128,7 @@ class TestAPIV2:
 
         res = client.get("/api/v2/models/analysis")
         assert res.status_code == 200
+
+    def test_api_nesting(self, client):
+        res = client.get("/api/v2/models/sample", params={"nest": "session", "all": True})
+        assert res.status_code == 200

--- a/backend/sparrow_tests/test_import_interface.py
+++ b/backend/sparrow_tests/test_import_interface.py
@@ -478,7 +478,10 @@ class TestNestedQuerying:
     def test_nested_querying(self, db):
         SampleSchema = db.interface.sample
         ss = SampleSchema(allowed_nests=["session", "analysis"])
-        relationships = ss.nested_relationships()
+        relationships = ss.nested_relationships(mode="inner")
         assert len(relationships) == 2
-        for rel in relationships:
-            assert isinstance(rel.property, RelationshipProperty)
+        relationships = ss.nested_relationships()
+        assert len(relationships) >= 2
+        for rel_list in relationships:
+            for rel in rel_list:
+                assert isinstance(rel.property, RelationshipProperty)

--- a/backend/sparrow_tests/test_import_interface.py
+++ b/backend/sparrow_tests/test_import_interface.py
@@ -481,4 +481,4 @@ class TestNestedQuerying:
         relationships = ss.nested_relationships()
         assert len(relationships) == 2
         for rel in relationships:
-            assert isinstance(rel, RelationshipProperty)
+            assert isinstance(rel.property, RelationshipProperty)

--- a/backend/sparrow_tests/test_import_interface.py
+++ b/backend/sparrow_tests/test_import_interface.py
@@ -478,8 +478,6 @@ class TestNestedQuerying:
     def test_nested_querying(self, db):
         SampleSchema = db.interface.sample
         ss = SampleSchema(allowed_nests=["session", "analysis"])
-        relationships = ss.nested_relationships(mode="inner")
-        assert len(relationships) == 2
         relationships = ss.nested_relationships()
         assert len(relationships) >= 2
         for rel_list in relationships:

--- a/backend/sparrow_tests/test_project_import.py
+++ b/backend/sparrow_tests/test_project_import.py
@@ -77,15 +77,8 @@ class TestProjectImport:
         SampleSchema = db.interface.sample
         ss = SampleSchema(many=True, allowed_nests=["session", "analysis"])
         q = db.session.query(ss.opts.model)
-        q = q.options(
-            joinedload(ss.opts.model.session_collection),
-            joinedload(ss.opts.model.session_collection, db.model.session.analysis_collection),
-            joinedload(
-                ss.opts.model.session_collection,
-                db.model.session.analysis_collection,
-                db.model.analysis.datum_collection,
-            ),
-        )
+        joins = [joinedload(*arg) for arg in ss.nested_relationships()]
+        q = q.options(*joins)
         res = q.all()
 
         assert len(res) > 0


### PR DESCRIPTION
We have a need for speed. This pull request is the starting point for _much_ faster API querying using SQLAlchemy. We now work out the join paths used by Marshmallow serialization schemas in advance, and apply them as `joinedload` options in the query, so all parts of the result are returned and assembled from a single database operation, even for deeply nested queries.

In our test case, this resulted in 96 database operations collapsing down to one!

This can be evolved in several ways:
- Use the `joinedload` strategy for queries outside the Marshmallow infrastructure
- Get a little more parsimonious within the `SmartNested` field: often we seem to pull back entire related models when we need only their primary key, or we already have the primary key on the parent model
- More testing, especially to achieve the second point
...but this is awesome for now!