### PR TITLE
Infinite scroll error

### DIFF
--- a/frontend/src/components/infinite-scroll/infinite-api-view.ts
+++ b/frontend/src/components/infinite-scroll/infinite-api-view.ts
@@ -1,10 +1,10 @@
-import { AppToaster } from "~/toaster";
 import { useEffect, useState } from "react";
 import ForeverScroll from "./forever-scroll";
 import { hyperStyled } from "@macrostrat/hyper";
 import { useAPIActions, setQueryString } from "@macrostrat/ui-components";
-import { Spinner, Callout } from "@blueprintjs/core";
+import { Spinner } from "@blueprintjs/core";
 import { NoSearchResults } from "./utils";
+import { ErrorCallout } from "~/util";
 import styles from "./main.styl";
 
 const h = hyperStyled(styles);
@@ -40,6 +40,7 @@ function InfiniteAPIView({
   componentProps = {},
   context,
   filterParams,
+  errorHandler = ErrorCallout,
 }) {
   const [data, setData] = useState([]);
   const [error, setError] = useState(null);
@@ -94,16 +95,7 @@ function InfiniteAPIView({
   };
 
   if (error) {
-    return h(
-      Callout,
-      {
-        title: "API Error",
-        icon: "error",
-        intent: "danger",
-        style: { marginTop: "10px" },
-      },
-      [h("p", error)]
-    );
+    return h(errorHandler, { error, title: "An API error has occured" });
   }
 
   return data.length > 0

--- a/frontend/src/components/infinite-scroll/infinite-api-view.ts
+++ b/frontend/src/components/infinite-scroll/infinite-api-view.ts
@@ -64,6 +64,7 @@ function InfiniteAPIView({
   }, []);
 
   const dataFetch = (data, next = "") => {
+    setNoResults(false);
     const initData = getNextPageAPI(next, url, params);
     initData.then((res) => {
       try {

--- a/frontend/src/components/infinite-scroll/main.styl
+++ b/frontend/src/components/infinite-scroll/main.styl
@@ -1,1 +1,4 @@
-
+.api-error
+    background-color #DB3737
+    color #FFFFFF
+    

--- a/frontend/src/components/infinite-scroll/main.styl
+++ b/frontend/src/components/infinite-scroll/main.styl
@@ -1,4 +1,2 @@
-.api-error
-    background-color #DB3737
-    color #FFFFFF
+
     

--- a/frontend/src/shared/ui-init.ts
+++ b/frontend/src/shared/ui-init.ts
@@ -1,6 +1,6 @@
 // Should import this in styles
 import "./ui-main.styl";
-import "core-js/stable";
+//import "core-js/stable";
 import "regenerator-runtime/runtime";
 import "@macrostrat/ui-components/lib/esm/index.css";
 import { FocusStyleManager } from "@blueprintjs/core";

--- a/frontend/src/util/error-boundary.tsx
+++ b/frontend/src/util/error-boundary.tsx
@@ -3,6 +3,22 @@ import { Callout } from "@blueprintjs/core";
 import { Route } from "react-router-dom";
 import h from "@macrostrat/hyper";
 
+function ErrorCallout(props) {
+  const { error, description, title } = props;
+
+  const des = description ? description : error.toString();
+
+  return h(
+    Callout,
+    {
+      title,
+      icon: "error",
+      intent: "danger",
+    },
+    [h("p", [des])]
+  );
+}
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
@@ -25,22 +41,18 @@ class ErrorBoundary extends React.Component {
       const { error } = this.state;
       if (description == null) description = error.toString();
       // You can render any custom fallback UI
-      return (
-        <Callout
-          title={"A rendering error occurred"}
-          icon="error"
-          intent="danger"
-        >
-          <p>{description}</p>
-        </Callout>
-      );
+      return h(ErrorCallout, {
+        error,
+        description,
+        title: "A rendering error has occured",
+      });
     }
 
     return this.props.children;
   }
 }
 
-const ErrorBoundaryRoute = function (props) {
+const ErrorBoundaryRoute = function(props) {
   const { component, render: baseRender, ...rest } = props;
 
   // Use render function unless component is provided
@@ -57,4 +69,4 @@ const ErrorBoundaryRoute = function (props) {
   });
 };
 
-export { ErrorBoundaryRoute, ErrorBoundary };
+export { ErrorBoundaryRoute, ErrorBoundary, ErrorCallout };


### PR DESCRIPTION
Work in progress! Has a hacky way of telling if there are no results versus if the results are still loading. There is an attempt at catching the error that occurs with nesting in an api call and using the `AppToaster` component to display it. The error being caught is a `can't read data of undefined` because the response from the api is undefined. The api call hangs for a while and then it breaks with a bad gateway 502 network error.