### PR TITLE
Fix api error

### DIFF
--- a/backend/sparrow/api/exceptions.py
+++ b/backend/sparrow/api/exceptions.py
@@ -11,10 +11,14 @@ class ValidationError(HTTPException):
         super().__init__(status_code=status_code, detail=detail)
 
 
-class SerializationError(HTTPException):
+class ApplicationError(HTTPException):
     def __init__(
         self,
         detail: typing.Union[None, str, typing.Dict[str, typing.List[str]]] = None,
         status_code: int = 500,
     ):
         super().__init__(status_code=status_code, detail=detail)
+
+
+class SerializationError(ApplicationError):
+    ...

--- a/backend/sparrow/database/__init__.py
+++ b/backend/sparrow/database/__init__.py
@@ -77,20 +77,20 @@ class Database:
         log.info("Finished automapping database")
 
     @contextmanager
-    def session_scope(self):
+    def session_scope(self, commit=True):
         """Provide a transactional scope around a series of operations."""
-        self.__old_session = self.session
-        session = self._session_factory()
-        self.session = session
+        # self.__old_session = self.session
+        # session = self._session_factory()
+        session = self.session
         try:
             yield session
-            session.commit()
+            if commit:
+                session.commit()
         except Exception:
             session.rollback()
             raise
         finally:
             session.close()
-            self.session = self.__old_session
 
     def model_schema(self, model_name) -> ModelSchema:
         """


### PR DESCRIPTION
Sometimes there is a database error on the API get requests caused by an improper query. When this happens, the API goes into a failure mode where the failed transactions returns errors continually from the database. The solution is to wrap everything in a transaction block that is rolled back on errors (using the db.session_scope context handler.

We should be doing something similar for basically every API route that touches the database. Perhaps this is worth making additional helper functions for.
