### PR TITLE
Api security

### DIFF
--- a/backend/core_plugins/__init__.py
+++ b/backend/core_plugins/__init__.py
@@ -6,7 +6,6 @@ from .project_edit import ProjectEditPlugin
 
 # These should only be run by labs that enable them
 from .versioning import VersioningPlugin
-from .import_data import ImportDataPlugin
 from .init_sql import InitSQLPlugin
 from .assets_server import AssetsServerPlugin
 from .data_file_server import DataFilePlugin

--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -1,3 +1,4 @@
+from sparrow.auth.api import UnauthorizedResponse
 from starlette.endpoints import HTTPEndpoint
 from webargs_starlette import parser
 from webargs.fields import DelimitedList, Str, Int, Boolean
@@ -6,6 +7,7 @@ from marshmallow_sqlalchemy.fields import get_primary_keys
 from sqlalchemy import desc
 from sqlalchemy.orm import joinedload
 from starlette.responses import JSONResponse
+from starlette.authentication import requires
 from yaml import safe_load
 
 from ...context import get_database
@@ -178,7 +180,12 @@ class ModelAPIEndpoint(HTTPEndpoint):
             schema = self.meta.schema(many=False, allowed_nests=args["nest"])
             # This needs to be wrapped in an error-handling block!
             q = db.session.query(schema.opts.model)
+
             res = q.get(id)
+            if not request.user.is_authenticated:
+                if res.embargo_date is not None:
+                    return UnauthorizedResponse()
+
             # https://github.com/djrobstep/sqlakeyset
             return APIResponse(res, schema=schema)
 
@@ -207,6 +214,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
 
     async def get(self, request):
         """Handler for all GET requests"""
+
         if request.path_params.get("id") is not None:
             # Pass off to the single-item handler
             return await self.get_single(request)
@@ -229,6 +237,9 @@ class ModelAPIEndpoint(HTTPEndpoint):
             for _filter in self._filters:
                 q = _filter(q, args)
 
+            if not request.user.is_authenticated:
+                q = q.filter(schema.opts.model.embargo_date == None)
+
             q = q.options(*list(schema.query_options(max_depth=1)))
 
             if args["all"]:
@@ -247,6 +258,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
 
             return APIResponse(res, schema=schema, total_count=q.count())
 
+    @requires("admin")
     async def put(self, request):
         """Handler for all PUT requests"""
 
@@ -297,6 +309,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
 
             return JSONResponse({"Status": f"success to {self._model_name}", "data": return_data})
 
+    @requires("admin")
     async def post(self, request):
         """
         Handler for all POST requests. i.e, New rows for database

--- a/backend/sparrow/api/endpoints/model.py
+++ b/backend/sparrow/api/endpoints/model.py
@@ -237,7 +237,7 @@ class ModelAPIEndpoint(HTTPEndpoint):
             for _filter in self._filters:
                 q = _filter(q, args)
 
-            if not request.user.is_authenticated:
+            if not request.user.is_authenticated and hasattr(schema.opts.model, "embargo_date"):
                 q = q.filter(schema.opts.model.embargo_date == None)
 
             q = q.options(*list(schema.query_options(max_depth=1)))

--- a/backend/sparrow/app/plugins.py
+++ b/backend/sparrow/app/plugins.py
@@ -10,6 +10,7 @@ from ..ext.data_validation import DataValidationPlugin
 from ..metrics_endpoint import MetricsEndpoint
 from ..web import WebPlugin
 from ..logs import get_logger
+from ..import_data import ImportDataPlugin
 
 log = get_logger(__name__)
 
@@ -29,6 +30,7 @@ def prepare_plugin_manager(app):
         ProjectEdits,
         DataValidationPlugin,
         MetricsEndpoint,
+        ImportDataPlugin
     )
     # GraphQL is disabled for now
     # self.plugins.add(GraphQLPlugin)

--- a/backend/sparrow/auth/api.py
+++ b/backend/sparrow/auth/api.py
@@ -27,7 +27,9 @@ async def login(request, username: str, password: str):
     log.debug(current_user)
 
     if current_user is not None and current_user.is_correct_password(password):
-        resp = JSONResponse(dict(login=True, username=username))
+        day = 24 * 60 * 60
+        token = backend.set_cookie(None, "access", max_age=day,identity=username)
+        resp = JSONResponse(dict(login=True, username=username, token=token))
         return backend.set_login_cookies(resp, identity=username)
 
     return backend.logout(UnauthorizedResponse(status_code=401))

--- a/backend/sparrow/auth/api.py
+++ b/backend/sparrow/auth/api.py
@@ -15,7 +15,7 @@ def get_backend():
 
 
 def UnauthorizedResponse(**kwargs):
-    return JSONResponse(dict(login=False, username=None), **kwargs)
+    return JSONResponse(dict(login=False, username=None, message="user is not authenticated"), **kwargs)
 
 
 @use_annotations(location="json")

--- a/backend/sparrow/datasheet/edits.py
+++ b/backend/sparrow/datasheet/edits.py
@@ -1,14 +1,17 @@
 from starlette.responses import JSONResponse
 from ..context import app_context
+from starlette.authentication import requires
 import json
 
 from .utils import material_check, make_changes
 
+
+@requires("admin")
 async def datasheet_edits(request):
     """
-    This will be the end route for the database editing. 
+    This will be the end route for the database editing.
 
-    The way to do this is be able to load the Sample table as a Sqlalchemy 
+    The way to do this is be able to load the Sample table as a Sqlalchemy
     class object and run update() on it.
 
     Use the automap_base() to create classes we can do sessions on
@@ -28,19 +31,19 @@ async def datasheet_edits(request):
     ## The issue is, we need to add some foriegn keys to the project and sample...
     ## add the project to the project_sample table and then publication to the project_pub table
     ## For NOW: fix by associating pub with the project that the sample is associated with..
-    ## If there are more than one publications leave it uneditable and have a button that goes 
+    ## If there are more than one publications leave it uneditable and have a button that goes
     # to sample the project page
     ## Try to create a relationship between the session and project and publication maybe
 
-    db = app_context().database ## This gives me access to the Database class
+    db = app_context().database  ## This gives me access to the Database class
 
     ## get the data from the post request and turn it into a dict.
     request_data = await request.json()
 
     ## for some reason this wasn't working with real request, only for tests...
-    #request_dict = json.loads(request_data)
+    # request_dict = json.loads(request_data)
 
-    ## grab the sample table from automap_base 
+    ## grab the sample table from automap_base
     table = db.model.sample
 
     ## function to make sure material passed is in vocab_material, if not add it.

--- a/backend/sparrow/import_data/__init__.py
+++ b/backend/sparrow/import_data/__init__.py
@@ -1,14 +1,14 @@
-from flask import current_app, request
-from flask_restful import Resource
-
+from starlette.endpoints import HTTPEndpoint
+from starlette.responses import JSONResponse
+from sparrow.context import app_context
 from sparrow import get_logger
-from sparrow.legacy.api_v1 import APIResourceCollection
 from sparrow.plugins import SparrowCorePlugin
+from starlette.routing import Route, Router
+from starlette.authentication import requires
+
 from sparrow.util import get_qualified_name
 
 log = get_logger(__name__)
-
-ImportDataAPI = APIResourceCollection()
 
 
 def construct_error_response(err: Exception, code: int):
@@ -34,30 +34,41 @@ def construct_error_response(err: Exception, code: int):
     )
 
 
-@ImportDataAPI.resource("/<string:model_name>")
-class ImportDataResource(Resource):
-    # We should enable authentication but that is tricky with scripts
-    # @jwt_required
+class ImportData(HTTPEndpoint):
+
+    # http://localhost:5002/api/v2/import-data/models/{model_name}
 
     # Raises a https://marshmallow.readthedocs.io/en/stable/api_reference.html#marshmallow.exceptions.ValidationError
     # when bad data is given
 
-    def put(self, model_name):
-        db = current_app.database
-        # TODO: lock this down so that login is required...!!!!
+    @requires("admin")
+    async def put(self, request):
+        db = app_context().database
         try:
-            req = request.get_json()
-            log.debug(req)
-            data = req.get("data")
+            model_name = request.path_params["model_name"]
+
+            data = await request.json()
+            log.debug(data)
             res = db.load_data(model_name, data)
             return res.id, 201
         except Exception as err:
             return construct_error_response(err, 400)
+    
+    async def get(self, request):
+        model_name = request.path_params["model_name"]
 
+
+        return JSONResponse({"Model": f"{model_name}"})
+
+ImportDataAPI = Router(
+      [
+        Route("/models/{model_name}", endpoint=ImportData, methods=["PUT","GET"]),
+    ]
+)
 
 class ImportDataPlugin(SparrowCorePlugin):
     name = "import-data"
     sparrow_version = ">=2.*"
 
-    def on_api_v1_initialized(self, api):
-        api.add_resource(ImportDataAPI, "/import-data")
+    def on_api_initialized_v2(self, api):
+        api.mount("/import-data", ImportDataAPI, name=self.name)

--- a/backend/sparrow/project_edits/base.py
+++ b/backend/sparrow/project_edits/base.py
@@ -1,7 +1,7 @@
 from starlette.endpoints import HTTPEndpoint
 from starlette.routing import Route, Router
 from starlette.responses import JSONResponse
-import json
+from starlette.authentication import requires
 
 from ..context import app_context
 
@@ -13,6 +13,7 @@ from ..context import app_context
 
 
 class ProjectEdits(HTTPEndpoint):
+    @requires("admin")
     async def put(self, request):
         """
         Improved endpoint for Admin Projects page. Using Schemas

--- a/backend/sparrow_tests/conftest.py
+++ b/backend/sparrow_tests/conftest.py
@@ -4,6 +4,7 @@ from starlette.testclient import TestClient
 from sparrow.app import Sparrow
 from sparrow.context import _setup_context
 from sparrow.database.util import wait_for_database
+from sparrow.auth.create_user import _create_user
 from sqlalchemy.orm import Session
 from sqlalchemy import event
 from .helpers.database import testing_database
@@ -110,3 +111,20 @@ def db(app, pytestconfig):
 def client(app, db):
     _client = TestClient(app)
     yield _client
+
+@fixture(scope="class")
+def token(db, client):
+    if db.session.query(db.model.user).get("test") == None:
+        user = "test"
+        password = "test"
+
+        _create_user(db, user, password)
+    res = client.post(
+            "/api/v2/auth/login", json={"username": "test", "password": "test"}
+        )
+
+    token = res.json()['token']
+
+    return token
+
+    

--- a/backend/sparrow_tests/test_auth.py
+++ b/backend/sparrow_tests/test_auth.py
@@ -114,3 +114,19 @@ class TestSparrowAuth:
             # We expect an assertion error here...
             return
         assert False
+
+    def test_access_token(self, client):
+        res = client.post(
+            "/api/v2/auth/login", json={"username": "Test", "password": "test"}
+        )
+        data = res.json()
+        assert 'error' not in data
+
+        token = data['token']
+
+        res = client.get(
+            "/api/v2/auth/secret"
+        )
+        data = res.json()
+        assert 'error' not in data
+        assert data['answer'] == 42

--- a/backend/sparrow_tests/test_importer_api.py
+++ b/backend/sparrow_tests/test_importer_api.py
@@ -7,13 +7,13 @@ import sys
 
 
 class TestAPIImporter:
-    def test_api_import(self, client):
-        res = client.put("/api/v1/import-data/session", json={"filename": None, "data": basic_data})
-        assert res.status_code == 201
+    def test_api_import(self, client,token):
+        res = client.put("/api/v2/import-data/models/session", headers={"Authorization":token}, json={"filename": None, "data": basic_data})
+        assert res.status_code == 200
 
-    def test_basic_import(self, client):
-        res = client.put("/api/v1/import-data/session", json=basic_d18O_data)
-        assert res.status_code == 201
+    def test_basic_import(self, client, token):
+        res = client.put("/api/v2/import-data/models/session", headers={"Authorization":token},json=basic_d18O_data)
+        assert res.status_code == 200
 
     @mark.skip
     def test_complex_single_row_prior(self, client, db):
@@ -44,7 +44,7 @@ class TestAPIImporter:
 
         db.load_data("session", complex_data["data"])
 
-    def test_very_large_import(self, client):
+    def test_very_large_import(self, client, token):
 
         import_size = 10
 
@@ -75,10 +75,10 @@ class TestAPIImporter:
             "analysis": analysis,
         }
 
-        res = client.put("/api/v1/import-data/session", json={"filename": None, "data": data})
-        assert res.status_code == 201
+        res = client.put("/api/v2/import-data/models/session",headers={"Authorization":token}, json={"filename": None, "data": data})
+        assert res.status_code == 200
 
-    def test_missing_field(self, client, db):
+    def test_missing_field(self, client, db, token):
         """Missing fields should produce a useful error message
         and insert no data"""
         new_name = "Test error vvv"
@@ -117,7 +117,7 @@ class TestAPIImporter:
             ],
         }
 
-        res = client.put("/api/v1/import-data/session", json={"filename": None, "data": data})
+        res = client.put("/api/v2/import-data/models/session", headers={"Authorization":token},json={"filename": None, "data": data})
         assert res.status_code == 400
         err = res.json()["error"]
 

--- a/backend/sparrow_tests/test_model_post.py
+++ b/backend/sparrow_tests/test_model_post.py
@@ -2,11 +2,11 @@ from .helpers import json_fixture
 from pytest import fixture, mark
 
 @fixture(scope="class")
-def test_projects(client):
+def test_projects(client, token):
     """Fixture to create a demo project"""
     data = json_fixture("projects-post.json")
     route = "/api/v2/models/project"
-    res = client.post(route, json=data)
+    res = client.post(route, headers={"Authorization":token},json=data)
     return res.json()["data"]
 
 class TestModelPost:
@@ -21,17 +21,17 @@ class TestModelPost:
         """
         assert len(test_projects) == 2
 
-    def test_replace_project(self, client, test_projects):
+    def test_replace_project(self, client, test_projects, token):
         id = test_projects[0]["id"]
         route = f"{self.route}/{id}"
         new_project = json_fixture("new-project.json")
-        res = client.post(route, json=new_project)
+        res = client.post(route, headers={"Authorization":token},json=new_project)
         data = res.json()
         # Need to actually test something here....
 
     @mark.skip(reason="This clearly needs some work")
-    def test_edit_researcher_in_project(self, client, test_projects):
+    def test_edit_researcher_in_project(self, client, test_projects, token):
         id = test_projects[0]["id"]
         edits = {"researcher": [{"name": "casey", "orcid": None}]}
-        client.put(f"{self.route}/{id}", json=edits)
+        client.put(f"{self.route}/{id}", headers={"Authorization":token},json=edits)
         # assert res_put.status_code == 200

--- a/backend/sparrow_tests/test_sims_import.py
+++ b/backend/sparrow_tests/test_sims_import.py
@@ -13,7 +13,7 @@ class TestSIMSImport:
         db.load_data("session", data)
 
 class TestSIMSWebscraper:
-    def test_webscrape_app_sims(self, db, client):
+    def test_webscrape_app_sims(self, db, client, token):
         """
         This test webscrapes an html page, taken from online.
 
@@ -50,7 +50,7 @@ class TestSIMSWebscraper:
         for i, title in enumerate(title_list):
             proj_titles.append({"name": title, "publications": [{"title": title, "doi": doi_list[i]}]})
 
-        res = client.post(route, json=proj_titles)
+        res = client.post(route, headers={"Authorization":token}, json=proj_titles)
 
         up_json = res.json()
         assert len(up_json["data"]) > 0


### PR DESCRIPTION
All post/put routes now require login authentication. The `import-data` route used by importers has been switched over to apiv2 and is not located at `/api/v2/import-data/models/{model_name}`. 

Authentication can now work through api access tokens that are returned from a successful login through the `/api/v2/auth/login` `post` route. To access restricted endpoints outside of browser, pass the token in `request.headers` as "Authorization." 

I noticed that we also have a bunch of failing tests now.. Probably because every post and put we do in them is now password protected. Maybe there's an easy way to provide a request header across all tests...