### PR TITLE
Fix install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,18 @@ jobs:
           body: |
             The latest release of Sparrow can be installed using the following command:
             ```
+            bash -c $(curl -fsSL https://raw.githubusercontent.com/EarthCubeGeochron/Sparrow/HEAD/get-sparrow.sh)
             curl -fsSL https://raw.githubusercontent.com/EarthCubeGeochron/Sparrow/HEAD/get-sparrow.sh | bash -s -
             ```
 
-            If you want to install this release specifically, you can add it to the above command,
-            like so: `... | bash -s - ${{ github.ref }}`.
+            - If you want to install this release specifically, you can add it to the above command,
+              like so: `bash -c $(...) - ${{ github.ref }}`.
+            - You can also download the installation
+              script manually and run it using `bash get-sparrow.sh` or `bash get-sparrow.sh $${{ github.ref }}`.
+            - For complete control over the installation process, you can manually run the download and installation steps
+              encapsulated by the [install script](https://github.com/EarthCubeGeochron/Sparrow/blob/HEAD/get-sparrow.sh).
 
-            See the [Getting started documentation](https://sparrow-data.org/docs/getting-started)
+            See the [Getting started documentation](https://sparrow-data.org/docs/getting-started).
             for more information on how to set up Sparrow.
       - name: Upload Sparrow CLI for release
         id: upload-release-asset 

--- a/get-sparrow.sh
+++ b/get-sparrow.sh
@@ -34,19 +34,17 @@ executable=$dist_dir/sparrow
 SUDO=""
 if ! [ -w $install_path ]
 then
-    echo "To install to $install_path elevated permissions are required!"
-    echo "If you choose to continue you will be prompted for your password."
+    echo "Elevated permissions are required to install to $install_path."
+    echo "If you choose to continue you may be prompted for your password."
     echo "Would you like to continue? (y/N)"
     read answer
     if [[ $answer == "y" || $answer == "Y" || $answer == "yes" || $answer == "Yes" ]]
     then
-        echo "Please enter your password."
         sudo bash -c "echo ''"
         SUDO="sudo"
-        echo ""
-        echo ""
     else 
         abort "No permissions granted."
+        echo ""
     fi
 fi
 
@@ -66,24 +64,23 @@ fi
 
 ## download into temp directory to see if it downloaded correctly
 echo "Downloading Sparrow CLI $version"
-echo
-echo
 curl -L -s ${url} | $SUDO tar xzf - -C $temp_dir
 
 test_file=$temp_dir/sparrow
 
 if [ -f "$test_file" ]; then
-        echo "You have successfully downloaded Sparrow!!"
-        echo
-        echo
-    else
-        abort "Download unsuccessful"
+  echo "...success!"
+else
+  abort "..download unsuccessful"
 fi
+
+echo ""
 
 $SUDO rm -rf $dist_dir
 $SUDO mkdir -p $dist_dir
 ## Move files to the correct directory
 # and test they have successfully moved
+echo "Installing to $dist_dir"
 $SUDO mv $temp_dir/* $dist_dir
 
 move_test_file=$dist_dir/sparrow
@@ -91,16 +88,19 @@ move_test_file=$dist_dir/sparrow
 if [ -f "$move_test_file" ]; 
 then
     rm -rf ${temp_dir}
+    echo "...success!"
 else
     rm -rf ${temp_dir}
-    abort "Problem when copying files"
+    abort "...copying unsuccessful"
 fi
 
+echo ""
 
 $SUDO mkdir -p $install_path/bin
 # Link executable onto the path
 echo "Linking $symlink -> $executable"
 $SUDO ln -sf "$executable" "$symlink"
 
-echo "Sparrow executable installed!"
+echo "...Sparrow executable installed!"
+echo ""
 echo "Check if you can run the 'sparrow' command. If not, you may need to add '$install_path/bin' to your PATH"

--- a/get-sparrow.sh
+++ b/get-sparrow.sh
@@ -1,26 +1,52 @@
 #!/bin/bash
 
 # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+get_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/${2:-latest}" | # Get latest release from GitHub api
     grep '"tag_name":' |                                            # Get tag line
     sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
 }
 
-abort() {
-    echo $1
-
-    echo "aborting..."
-    exit
+header() {
+  >&2 echo -e "\e[1m$1\e[0m"
 }
+
+say() {
+  >&2 echo -e "   $1"
+}
+
+
+abort() {
+    say "$1"
+    say "exiting"
+    exit 1
+}
+
 
 ################################################################### script
 
 repo_name=EarthCubeGeochron/Sparrow
-version=${1:-$(get_latest_release $repo_name)}
-platform=$(uname -s)
 
-url=https://github.com/$repo_name/releases/download/$version/sparrow-$platform-x86_64.tar.gz
+platform=$(uname -s)
+header "Installing Sparrow on $platform"
+say ""
+
+# Get the version of Sparrow to install, either from the user or
+# the latest tagged release on GitHub
+
+# Release should be last argument to the script if provided
+release="$1"
+if [ -z $release ]; then
+  header "Finding latest Sparrow release"
+  release=$(get_release $repo_name latest)
+  say "found release $release"
+else
+  header "Finding user-specified version $release"
+fi
+say ""
+
+
+url=https://github.com/$repo_name/releases/download/$release/sparrow-$platform-x86_64.tar.gz
 
 install_path=${SPARROW_INSTALL_PATH:-${INSTALL_PATH:-/usr/local}}
 build_dir=_cli/dist/sparrow
@@ -29,69 +55,85 @@ symlink=$install_path/bin/sparrow
 executable=$dist_dir/sparrow
 #TMPDIR=$install_path/sparrowtemp
 
+# Check whether URL exists
+header "Checking download link"
+say "\e[2m$url\e[0m"
+if curl --output /dev/null --silent --head --fail "$url"; then
+  say "link is accessible!"
+else
+  abort "could not access link!"
+fi
+echo ""
+
+header "Installation prefix:\e[0m $install_path"
+say "The following locations will be written"
+say "- $dist_dir"
+say "- $symlink"
+say
+
 #check permissions
 # if permissions are needed it will notify and attempy a sudo login
 SUDO=""
-if ! [ -w $install_path ]
+if ! [ -w $install_path ]; then
+    header "Permissions"
+    say "Elevated permissions are required to install to $install_path."
+    say "You may be prompted for your password."
+    say ""
+fi
+
+# Ask for confirmation no matter what
+echo "Would you like to continue? (y/N)"
+read -r answer
+
+if [[ $answer == "y" || $answer == "Y" || $answer == "yes" || $answer == "Yes" ]]
 then
-    echo "Elevated permissions are required to install to $install_path."
-    echo "If you choose to continue you may be prompted for your password."
-    echo "Would you like to continue? (y/N)"
-    read answer
-    if [[ $answer == "y" || $answer == "Y" || $answer == "yes" || $answer == "Yes" ]]
-    then
-        sudo bash -c "echo ''"
-        SUDO="sudo"
-    else 
-        abort "No permissions granted."
-        echo ""
-    fi
+  echo ""
+else
+  abort "Installation cancelled"
+fi
+
+SUDO=""
+if ! [ -w $install_path ]; then
+    sudo bash -c "echo ''" || abort "no permissions granted."
+    SUDO="sudo"
 fi
 
 
 ## create temporary directory using the TMPDIR environmental variable
 temp_dir=$(mktemp -d)
 if [ ! -d $temp_dir ]; then
-  echo "$temp_dir not created successfully"
-  exit 1
-fi
-
-## check header to make sure url exists
-if [ $(curl -I -s ${url} | grep -c "Not Found") -eq 1 ]
-then 
-    abort "${url} not found"
+  abort "$temp_dir not created successfully"
 fi
 
 ## download into temp directory to see if it downloaded correctly
-echo "Downloading Sparrow CLI $version"
+header "Downloading Sparrow CLI \e[0m$release"
 curl -L -s ${url} | $SUDO tar xzf - -C $temp_dir
 
 test_file=$temp_dir/sparrow
 
 if [ -f "$test_file" ]; then
-  echo "...success!"
+  say "success!"
 else
-  abort "..download unsuccessful"
+  abort "download unsuccessful"
 fi
-
 echo ""
 
+echo "clearing out $dist_dir"
 $SUDO rm -rf $dist_dir
 $SUDO mkdir -p $dist_dir
 ## Move files to the correct directory
 # and test they have successfully moved
-echo "Installing to $dist_dir"
+echo "installing to $dist_dir"
 $SUDO mv $temp_dir/* $dist_dir
 
 move_test_file=$dist_dir/sparrow
 
+rm -rf $temp_dir
 if [ -f "$move_test_file" ]; 
 then
-    rm -rf ${temp_dir}
-    echo "...success!"
+    say "success!"
 else
-    rm -rf ${temp_dir}
-    abort "...copying unsuccessful"
+    abort "copying unsuccessful"
 fi
 
 echo ""
@@ -100,7 +142,10 @@ $SUDO mkdir -p $install_path/bin
 # Link executable onto the path
 echo "Linking $symlink -> $executable"
 $SUDO ln -sf "$executable" "$symlink"
-
-echo "...Sparrow executable installed!"
 echo ""
-echo "Check if you can run the 'sparrow' command. If not, you may need to add '$install_path/bin' to your PATH"
+
+header "\e[32mSparrow executable installed!\e[0m"
+
+say
+say "Check if you can run the 'sparrow' command."
+say "If not, you may need to add '$install_path/bin' to your PATH"

--- a/get-sparrow.sh
+++ b/get-sparrow.sh
@@ -66,9 +66,13 @@ fi
 echo ""
 
 header "Installation prefix:\e[0m $install_path"
-say "The following locations will be written"
-say "- $dist_dir"
-say "- $symlink"
+say "\e[1m\e[2mTip:\e[0m \e[2mthe installation prefix can be controlled with the"
+say "\e[0mSPARROW_INSTALL_PATH\e[2m or \e[0mINSTALL_PATH\e[2m environment variables."
+echo -e "\e[0m"
+
+echo -e "The following locations will be written"
+echo -e "- $dist_dir"
+echo -e "- $symlink"
 say
 
 #check permissions


### PR DESCRIPTION
- Updated install command so it should work both with and without sudo access (but will fail if sudo access is needed)
- Made the command log nicely


The install command should now be run using `bash -c $(curl -fsSL https://raw.githubusercontent.com/EarthCubeGeochron/Sparrow/HEAD/get-sparrow.sh)`

If you want to specify a version, you can run `bash -c $(curl -fsSL https://raw.githubusercontent.com/EarthCubeGeochron/Sparrow/HEAD/get-sparrow.sh) - v2.0.0.beta1`. 