### PR TITLE
Added a websockets API that provides a server 'heartbeat'

### DIFF
--- a/backend/sparrow/app/plugins.py
+++ b/backend/sparrow/app/plugins.py
@@ -6,6 +6,7 @@ from ..auth import AuthPlugin
 from ..ext.pychron import PyChronImportPlugin
 from ..datasheet import DatasheetPlugin
 from ..project_edits import ProjectEdits
+from ..ext import HeartbeatPlugin
 from ..ext.data_validation import DataValidationPlugin
 from ..metrics_endpoint import MetricsEndpoint
 from ..tags import Tags
@@ -28,6 +29,7 @@ def prepare_plugin_manager(app):
         APIv2Plugin,
         AuthPlugin,
         WebPlugin,
+        HeartbeatPlugin,
         InterfacePlugin,
         PyChronImportPlugin,
         DatasheetPlugin,

--- a/backend/sparrow/ext/__init__.py
+++ b/backend/sparrow/ext/__init__.py
@@ -1,1 +1,2 @@
 from .cloud_data import CloudDataPlugin
+from .heartbeat import HeartbeatPlugin

--- a/backend/sparrow/ext/heartbeat.py
+++ b/backend/sparrow/ext/heartbeat.py
@@ -1,0 +1,22 @@
+from starlette.endpoints import WebSocketEndpoint
+from sparrow.plugins import SparrowCorePlugin
+from sparrow_utils import get_logger
+
+log = get_logger(__name__)
+
+
+class Heartbeat(WebSocketEndpoint):
+    async def send_ok(self, session):
+        await session.send_json({"status": "ok"})
+
+    async def on_receive(self, session):
+        log.info("Received ping")
+        await self.send_ok(session)
+
+
+class HeartbeatPlugin(SparrowCorePlugin):
+    name = "heartbeat"
+    dependencies = ["api-v2"]
+
+    def on_api_initialized_v2(self, api):
+        api.add_websocket_route("/heartbeat", Heartbeat)

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -7,3 +7,4 @@ export * from "./misscel";
 export * from "./blueprint.select";
 export * from "./tags";
 export * from "./open-search";
+export * from "./server-status";

--- a/frontend/src/components/server-status.ts
+++ b/frontend/src/components/server-status.ts
@@ -1,0 +1,63 @@
+import { Button, IconName, Intent } from "@blueprintjs/core";
+import h from "@macrostrat/hyper";
+import { APIV2Context } from "~/api-v2";
+import useWebSocket, { ReadyState } from "react-use-websocket";
+import { useState, useCallback, useContext } from "react";
+
+function ServerStatus(props) {
+  const [reconnectAttempt, setReconnectAttempt] = useState(1);
+  const [hasEverConnected, setConnected] = useState(false);
+  const ctx = useContext(APIV2Context);
+  const getSocketUrl = useCallback(() => {
+    return new Promise((resolve) => {
+      let uri = ctx.baseURL;
+      // Get absolute and websocket URL
+      if (!uri.startsWith("http")) {
+        const { protocol, host } = window.location;
+        uri = `${protocol}//${host}${uri}`;
+      }
+      uri = uri.replace(/^http(s)?:\/\//, "ws$1://") + "/heartbeat";
+      console.log(uri);
+      resolve(uri);
+    });
+  }, [ctx, reconnectAttempt]);
+
+  const { sendMessage, lastMessage, readyState } = useWebSocket(getSocketUrl, {
+    onOpen: () => setConnected(true),
+    shouldReconnect: (closeEvent) => {
+      return true;
+    },
+    reconnectAttempts: 10,
+    reconnectInterval: 3000,
+  });
+
+  let icon: IconName = "tick";
+  let intent: Intent = "success";
+  let text: string = "Connected";
+  if (!hasEverConnected) {
+    icon = "error";
+    intent = "danger";
+    text = "Server not found";
+  } else if (readyState != ReadyState.OPEN) {
+    icon = "warning-sign";
+    intent = "warning";
+    text = "Server disconnected";
+  }
+
+  return h(
+    Button,
+    {
+      minimal: true,
+      small: true,
+      icon,
+      intent,
+      onClick() {
+        if (readyState != ReadyState.OPEN)
+          setReconnectAttempt(reconnectAttempt + 1);
+      },
+    },
+    text
+  );
+}
+
+export { ServerStatus };

--- a/frontend/src/shared/footer.ts
+++ b/frontend/src/shared/footer.ts
@@ -1,14 +1,20 @@
 import h from "react-hyperscript";
 import { Frame } from "sparrow/frame";
-import { Markdown } from "@macrostrat/ui-components";
-import { InsetText } from "app/components/layout";
-import footerText from "./footer-text.md";
+import { ServerStatus } from "../components";
 
-const PageFooter = (props) =>
-  h(
-    Frame,
-    { id: "pageFooter" },
-    h(InsetText, null, h(Markdown, { src: footerText }))
-  );
+const PageFooter = (props) => {
+  return h("footer", [
+    h(Frame, { id: "pageFooter" }, h("div")),
+    h("div.powered-by.flex-container", [
+      h("p", [
+        "Powered by ",
+        h("b", null, h("a", { href: "https://sparrow-data.org" }, "Sparrow")),
+        " ",
+      ]),
+      h("div.status", null, h(ServerStatus)),
+      h("div.spacer"),
+    ]),
+  ]);
+};
 
 export { PageFooter };

--- a/frontend/src/shared/ui-main.styl
+++ b/frontend/src/shared/ui-main.styl
@@ -66,3 +66,21 @@ div.api-explorer-v2
   margin-top 1em
   .swagger-ui .info
     margin-top 1em
+
+.flex-container
+  display flex
+  flex-direction row
+  align-items: baseline
+  &>*
+    margin-right 1em
+    vertical-align: baseline
+    margin-bottom 0
+    margin-top 0
+    &:last-child
+      margin-right 0
+    &.spacer
+      flex-grow 1
+
+footer
+  margin-bottom 1em
+


### PR DESCRIPTION
This PR adds a websocket at `/api/v2/heartbeat` that echos `{status: ok}` on messages.

This allows the frontend to monitor whether it is properly connected to a running Sparrow server. Accordingly, we have created a small button that shows the connection status in the footer of the Sparrow site, and allows reconnection attempts on click. We may move this.

<img width="131" alt="image" src="https://user-images.githubusercontent.com/1537910/124368180-2275a200-dc24-11eb-9c22-eac596d087a6.png">

This fix goes partway to solving the server issues that we have been seeing in #161 and #167, at least by letting us see more clearly when problems may be due to a non-responsive server.

