### PR TITLE
Refresh search index task

### DIFF
--- a/backend/sparrow/open_search/__init__.py
+++ b/backend/sparrow/open_search/__init__.py
@@ -3,6 +3,8 @@ from sparrow.context import app_context
 from sparrow.util import relative_path
 from starlette.routing import Route, Router
 from starlette.responses import JSONResponse
+import sparrow
+from sparrow.task_manager.task import task
 import pandas as pd
 from pathlib import Path
 import json
@@ -19,8 +21,10 @@ class OpenSearch(SparrowCorePlugin):
     name = "open-search"
     dependencies = ["versioning"]
 
-    def initialize_tables(self, db):
+    def initialize_tables(self, db, refresh=True):
         initialization_fn = procedures / "on-initialization.sql"
+        if refresh:
+            db.exec_sql(procedures / "drop-tables.sql")
 
         filenames = list(fixtures.glob("*.sql"))
         filenames.sort()
@@ -38,3 +42,11 @@ class OpenSearch(SparrowCorePlugin):
 
     def on_api_initialized_v2(self, api):
         api.mount("/search", OpenSearchAPI, name=self.name)
+
+
+@task(name="refresh-search-index")
+def refresh_search_triggers():
+    """Refresh open search triggers in case they get out of sync."""
+    db = sparrow.get_database()
+    open_search = sparrow.get_plugin("open-search")
+    open_search.initialize_tables(db)

--- a/backend/sparrow/open_search/procedures/drop-tables.sql
+++ b/backend/sparrow/open_search/procedures/drop-tables.sql
@@ -1,0 +1,7 @@
+/*
+A procedure to run at initialization if the document tables are empty. 
+*/
+
+DROP TABLE documents.project_document;
+DROP TABLE documents.sample_document;
+DROP TABLE documents.session_document;

--- a/backend/sparrow/open_search/procedures/on-initialization.sql
+++ b/backend/sparrow/open_search/procedures/on-initialization.sql
@@ -5,16 +5,16 @@ A procedure to run at initialization if the document tables are empty.
 DO $$
 BEGIN
 IF (NOT EXISTS(SELECT FROM documents.project_document)) THEN
-    SELECT project_doc_insert(p.id) FROM project p;
+    PERFORM project_doc_insert(p.id) FROM project p;
 END IF;
 
 
 IF (NOT EXISTS(SELECT FROM documents.sample_document)) THEN
-    SELECT sample_doc_insert(s.id) FROM sample s;
+    PERFORM sample_doc_insert(s.id) FROM sample s;
 END IF;
 
 IF (NOT EXISTS(SELECT FROM documents.session_document)) THEN
-    SELECT session_doc_insert(ss.id) FROM session ss;
+    PERFORM session_doc_insert(ss.id) FROM session ss;
 END IF;
 END
 $$


### PR DESCRIPTION
This task helps guard against out-of-sync search indices, which can happen inadvertently if triggers aren't created at the right time.

We should remove this task once we solve the underlying issue with triggers not being created.