### PR TITLE
Datafile List Searching Error

### DIFF
--- a/frontend/src/admin/data-file.ts
+++ b/frontend/src/admin/data-file.ts
@@ -15,12 +15,12 @@ export function DataFilesMainPanel() {
   return h(Switch, [
     h(Route, {
       path: base + "/:file_hash",
-      component: () => h(DataFileMatch),
+      component: () => h(DataFileMatch)
     }),
     h(Route, {
       path: base,
-      component: () => h(NoStateAdmin, { name: "Data File" }),
-    }),
+      component: () => h(NoStateAdmin, { name: "Data File" })
+    })
   ]);
 }
 
@@ -31,8 +31,13 @@ export function DataFileAdminPage() {
 
   const [params, setParams] = useState(initialState);
 
-  const createParams = (params) => {
+  const createParams = params => {
     for (let [key, value] of Object.entries(params)) {
+      console.log(key, value);
+      if (key == "search") {
+        params["like"] = params[key];
+        delete params[key];
+      }
       if (value == null) {
         delete params[key];
       }
@@ -45,8 +50,8 @@ export function DataFileAdminPage() {
       listComponent: h(DataFilesListComponent, { params }),
       possibleFilters,
       createParams,
-      initParams: params || {},
+      initParams: params || {}
     }),
-    mainPageComponent: h(DataFilesMainPanel),
+    mainPageComponent: h(DataFilesMainPanel)
   });
 }

--- a/frontend/src/components/open-search/index.ts
+++ b/frontend/src/components/open-search/index.ts
@@ -6,7 +6,7 @@ import {
   ProjectModelCard,
   SessionListModelCard,
   SampleModelCard,
-  ModelCard,
+  ModelCard
 } from "~/model-views/components";
 import ForeverScroll from "~/components/infinite-scroll/forever-scroll";
 import { SearchInput } from "~/filter/components";
@@ -15,13 +15,13 @@ import styles from "./module.styl";
 
 const h = hyperStyled(styles);
 
-const OpenSearchCard = (props) => {
+const OpenSearchCard = props => {
   const { model, data } = props;
 
   let possibleModels = {
     sample: SampleModelCard,
     project: ProjectModelCard,
-    session: SessionListModelCard,
+    session: SessionListModelCard
   };
   let data_ = { ...data, showIdentity: "long" };
   for (const key in possibleModels) {
@@ -38,7 +38,7 @@ const OpenSearchCard = (props) => {
 function OpenSearch() {
   const [query, setQuery] = useState("");
   const [scrollData, setScrollData] = useState<any>([]);
-  const url = "/api/v2/search/query";
+  const url = "search/query";
 
   const data = useAPIv2Result(url, { query: query, model: "all" });
 
@@ -69,16 +69,16 @@ function OpenSearch() {
       h(SearchInput, {
         leftElement: h(Icon, { icon: "search" }),
         updateParams: onChange,
-        value: query,
-      }),
+        value: query
+      })
     ]),
     h("div.results", [
       h.if(scrollData.length > 0)(ForeverScroll, {
         initialData: scrollData,
         component: OpenSearchCard,
-        fetch: () => {},
-      }),
-    ]),
+        fetch: () => {}
+      })
+    ])
   ]);
 }
 

--- a/frontend/src/filter/index.tsx
+++ b/frontend/src/filter/index.tsx
@@ -7,7 +7,7 @@ import {
   DoiFilter,
   SearchInput,
   GeologicFormationSelector,
-  TagFilter,
+  TagFilter
 } from "./components";
 import { useToggle } from "~/components";
 import { hyperStyled } from "@macrostrat/hyper";
@@ -34,7 +34,7 @@ function SampleFilter({ on_map = false }: Filter) {
     return h(Card, [
       h(AgeSlideSelect),
       h(DatePicker, { updateDateRange: () => {} }),
-      h(GeologicFormationSelector),
+      h(GeologicFormationSelector)
     ]);
   };
 
@@ -44,20 +44,20 @@ function SampleFilter({ on_map = false }: Filter) {
       {
         content: h(filterCard),
         minimal: true,
-        position: "bottom",
+        position: "bottom"
       },
       [
         h(Tooltip, { content: "Choose Multiple Filters" }, [
           h(Button, { onClick: toggleOpen, minimal: true }, [
-            h(Icon, { icon: "filter" }),
-          ]),
-        ]),
+            h(Icon, { icon: "filter" })
+          ])
+        ])
       ]
-    ),
+    )
   ]);
 }
 
-const TagContainer = (props) => {
+const TagContainer = props => {
   const [tags, setTags] = useState({});
   const { params, removeParam, createParams } = props;
 
@@ -74,7 +74,7 @@ const TagContainer = (props) => {
     return newObject;
   }
 
-  const handleRemove = (key) => {
+  const handleRemove = key => {
     removeParam(key);
     const newTags = objectFilter(tags, ([ke, value]) => ke != key);
     setTags(newTags);
@@ -85,17 +85,17 @@ const TagContainer = (props) => {
     geometry: "Map Location",
     date_range: "Date Range",
     doi_like: "doi",
-    public: { true: "Public Only", false: "Private Only" },
+    public: { true: "Public Only", false: "Private Only" }
   };
 
   if (Object.keys(tags).length != 0) {
     return h("div.tag-container", [
-      Object.entries(tags).map((entry) => {
+      Object.entries(tags).map(entry => {
         const [key, value] = entry;
         const name =
           key == "public"
             ? natLang[key][value]
-            : key == "search"
+            : key == "search" || key == "like"
             ? value
             : natLang[key];
         return h(
@@ -103,7 +103,7 @@ const TagContainer = (props) => {
           { onRemove: () => handleRemove(key), className: "tag-individ" },
           [name]
         );
-      }),
+      })
     ]);
   }
   return null;
@@ -117,7 +117,7 @@ function AdminFilter(props) {
     listComponent,
     initParams,
     dropdown = false,
-    addModelButton = null,
+    addModelButton = null
   } = props;
 
   const [params, dispatch] = useReducer(reducer, initParams);
@@ -141,7 +141,7 @@ function AdminFilter(props) {
       dispatch({ type: "search", payload: { search: data } });
     }
   };
-  const removeParam = (key) => {
+  const removeParam = key => {
     dispatch({ type: "removeSingle", payload: { field: key } });
   };
 
@@ -152,7 +152,7 @@ function AdminFilter(props) {
     urlSearchFromParams(params);
   };
 
-  const onSearch = (e) => {
+  const onSearch = e => {
     e.preventDefault();
     createParams(params);
     setTags(params);
@@ -163,7 +163,7 @@ function AdminFilter(props) {
       Button,
       {
         intent: "primary",
-        onClick: onSubmit,
+        onClick: onSubmit
       },
       ["Apply Filters"]
     );
@@ -174,7 +174,7 @@ function AdminFilter(props) {
       {
         intent: "danger",
         onClick: () => setFilterOpen(!filterOpen),
-        style: { marginLeft: "10px" },
+        style: { marginLeft: "10px" }
       },
       ["Cancel"]
     );
@@ -184,33 +184,33 @@ function AdminFilter(props) {
     "div",
     {
       style: {
-        marginTop: "15px",
-      },
+        marginTop: "15px"
+      }
     },
     [
       h("div", [
         h.if(possibleFilters.includes("public"))(EmabrgoSwitch, {
-          updateEmbargoFilter: updateParams,
+          updateEmbargoFilter: updateParams
         }),
         h.if(possibleFilters.includes("tag"))(TagFilter, {
-          updateParams,
+          updateParams
         }),
         h("div", [
           h.if(possibleFilters.includes("date_range"))(DatePicker, {
-            updateDateRange: updateParams,
-          }),
+            updateDateRange: updateParams
+          })
         ]),
         h.if(possibleFilters.includes("doi_like"))(DoiFilter, {
-          updateDoi: updateParams,
+          updateDoi: updateParams
         }),
         h.if(possibleFilters.includes("geometry"))(MapPolygon, {
-          updateParams,
+          updateParams
         }),
         h("div", { style: { margin: "10px", marginLeft: "0px" } }, [
           h(SumbitFilterButton),
-          h(CancelFilterButton),
-        ]),
-      ]),
+          h(CancelFilterButton)
+        ])
+      ])
     ]
   );
 
@@ -228,16 +228,16 @@ function AdminFilter(props) {
           isOpen: open,
           content: Content,
           minimal: true,
-          position: "bottom",
+          position: "bottom"
         },
         [
           h(Tooltip, { content: "Choose Multiple Filters" }, [
             h(Button, { minimal: true, onClick: changeOpen }, [
-              h(Icon, { icon: "filter" }),
-            ]),
-          ]),
+              h(Icon, { icon: "filter" })
+            ])
+          ])
         ]
-      ),
+      )
     ]);
   };
 
@@ -252,21 +252,21 @@ function AdminFilter(props) {
         leftElement: h(Button, {
           icon: "filter",
           onClick: () => setFilterOpen(!filterOpen),
-          minimal: true,
+          minimal: true
         }),
         updateParams,
         rightElement: h(Button, {
           icon: "search",
           onClick: onSearch,
           minimal: true,
-          type: "submit",
+          type: "submit"
         }),
-        text: params.search || "",
+        text: params.search || ""
       }),
       h(TagContainer, { params: tags, removeParam, createParams }),
-      addModelButton,
+      addModelButton
     ]),
-    filterOpen ? Content : listComponent,
+    filterOpen ? Content : listComponent
   ]);
 }
 


### PR DESCRIPTION
Some fixes for #218. The `OpenSearch` currently does not work for datafiles because there was never a document schema created for datafile. However, the frontend search filtering was set by default to use the `OpenSearch` filter. I moved the frontend parameters to use the older, less robust `like` filter. 

Not entirely sure what @davenquinn means by "other Open Search endpoints are pretty broken." The admin base wasn't working because the api request was adding an extra `/api/v2/` that wasn't an issue before, that is fixed. My local branch isn't showing issues with Projects, Samples, or Sessions. My intuition says that if there are issues it is be because the data models aren't being added correctly to the document schemas, a problem I believed we fixed but may require another look.