### PR TITLE
Fix startup bug

### DIFF
--- a/_cli/sparrow_cli/help/options_cache.py
+++ b/_cli/sparrow_cli/help/options_cache.py
@@ -41,7 +41,7 @@ def get_backend_help_info(cache=True):
         stdout=PIPE,
         env=env,
         tty=False,
-        run_args=("--no-deps --rm -T",),
+        run_args=("--no-deps --rm",),
     )
     if out.returncode != 0:
         details = str(b"\n".join(out.stdout.splitlines()[1:]), "utf-8") + "\n"

--- a/_cli/sparrow_cli/util/shell.py
+++ b/_cli/sparrow_cli/util/shell.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from json import loads
 from json.decoder import JSONDecodeError
 from sparrow_utils.logs import get_logger
-from sparrow_utils.shell import cmd as cmd_
+from sparrow_utils.shell import split_args, cmd as cmd_
 from rich import print
 from .exceptions import SparrowCommandError
 
@@ -65,8 +65,10 @@ def exec_or_run(
             *compose_args, "exec", *tty_args, container, *args, **popen_kwargs
         )
     else:
+        run_args = split_args(*run_args)
+        run_args = list(set([*tty_args, *run_args]))
         return compose(
-            *compose_args, "run", *tty_args, *run_args, container, *args, **popen_kwargs
+            *compose_args, "run", *run_args, container, *args, **popen_kwargs
         )
 
 

--- a/backend/utils/sparrow_utils/__init__.py
+++ b/backend/utils/sparrow_utils/__init__.py
@@ -4,7 +4,7 @@ core and command-line interface.
 """
 from os import path
 from .logs import setup_stderr_logs, get_logger
-from .shell import cmd
+from .shell import cmd, split_args
 
 
 def relative_path(base, *parts):


### PR DESCRIPTION
This resolves a bug with loading configuration for Sparrow command-line options, part of #243, which arises from invalid usage of `docker-compose run` on initial application setup.