### PR TITLE
Linux build fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           python-version: '3.9'
 
-        # Bundling
+      # Bundling (note: we build the CLI in Docker to support older Linux platforms)
       - name: Bundle command-line application with PyInstaller
-        run: make build && sudo make install
+        run: make build-linux && sudo make install-dist
 
       - name: Check version consistency
         run: SPARROW_PATH=$(pwd) sparrow dev check-version --exact

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/sadisplay"]
 	path = deps/sadisplay
-	url = git://github.com/davenquinn/sadisplay.git
+	url = https://github.com/davenquinn/sadisplay.git
 [submodule "backend/core_plugins/versioning/pg-memento"]
 	path = backend/core_plugins/versioning/pg-memento
 	url = https://github.com/pgMemento/pgMemento.git

--- a/Makefile
+++ b/Makefile
@@ -40,23 +40,28 @@ _cli/dist/macos/sparrow:
 	# Due to the vagaries of PyInstaller, Mac distribution must be built on OS X
 	pyinstaller --distpath _cli/dist/macos _cli/sparrow.spec
 
-_cli/dist/linux/sparrow:
+# Build locally for the current platform (DEFAULT)
+_cli/dist/sparrow:
+	_cli/_scripts/build-dist
+
+build-linux:
 	docker run -it \
 		-v "$(shell pwd):/src/" \
 		cdrx/pyinstaller-linux:latest \
 		_cli/_scripts/build-dist
 
-_cli/dist/windows/sparrow:
-	docker run -v "$(shell pwd)/_cli:/src" cdrx/pyinstaller-windows:latest
+# This will build the CLI for windows, which is currently unsupported
+# (WSL integration with the linux binaries should be used instead)
+build-windows:
+	docker run -it \
+		-v "$(shell pwd):/src/" \
+		cdrx/pyinstaller-windows:latest \
+		_cli/_scripts/build-dist
 
-# Build locally for the current platform
-_cli/dist/sparrow:
-	_cli/_scripts/build-dist
-
+# Helper to generate a build specification
 _generate_buildspec:
 	cd _cli && \
 	pyinstaller --noconfirm --distpath dist sparrow_cli/__main__.py
-	# docker run -v "$(shell pwd)/_cli/:/src/" cdrx/pyinstaller-linux "pyinstaller main.py"
 
 # Link git hooks
 # (handles automatic submodule updating etc.)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ _cli/dist/macos/sparrow:
 	pyinstaller --distpath _cli/dist/macos _cli/sparrow.spec
 
 _cli/dist/linux/sparrow:
-	docker run -v "$(shell pwd)/_cli:/src" cdrx/pyinstaller-linux:latest
+	docker run -it \
+		-v "$(shell pwd):/src/" \
+		cdrx/pyinstaller-linux:latest \
+		_cli/_scripts/build-dist
 
 _cli/dist/windows/sparrow:
 	docker run -v "$(shell pwd)/_cli:/src" cdrx/pyinstaller-windows:latest


### PR DESCRIPTION
- Refresh Docker-based CLI builder (based on `cdrx/pyinstaller-linux` image)
- Use Docker workflow rather than a local build on the Github Actions worker
- Addresses #246 